### PR TITLE
Multi-Arch Support, Initially Supporting AMD64 and AArch64 (aka ARM64v8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,49 @@
-Hyperkube Images for Rancher
-============================
+# Hyperkube Images for Rancher
 
 Rancher 2.0 is built off of Kubernetes upstream hyperkube images (gcr/google_containers/hyperkube).  This repo repackages the hyperkube images for Rancher.
 
-There is one branch per minor release of Kubernetes.  For example v1.8, v1.9, v1.10, etc.
+There is now one folder per release of Kubernetes, and subsequently one per architecture to allow for multi-arch support.
+
+## Requirements
+
+* manifest-tool
+* docker
+  * docker server with binfmt_misc setup for multi-arch images (if you have docker for mac, it already does this for you)
+
+## Building
+
+The script currently builds all versions and all architectures.
+
+```bash
+bash build.sh
+```
+
+If you want to push to the registry, set `PUSH` to any value, assuming you've set other variables and permissions are correct everything will work.
+
+### Change Repo Prefix
+
+If you need to change the prefix of the images, `export REPO=ekristen`
+
+This will result in images being built as `ekristen/hyperkube:VERSION-ARCH`
+
+### Private Registry
+
+If using a private registry, `export PRIVATE_REGISTRY=1`
+
+You will also need to export REGISTRY_USERNAME and REGISTRY_PASSWORD for manifest publishing.
+
+## Adding New Versions
+
+Adding new versions is just about duplicating the existing folder structure for a previous image and updating the FROM. 
+
+Once you know the version of hyperkube you are wanting to add, you can inspect it's manifest on the gcr.io registry to determine the digest to target.
+
+```
+docker manifest inspect gcr.io/google_containers/hyperkube:v1.12.1
+```
+
+Find the one for AMD64 and use the digest for the FROM address, repeat the process for other architectures you want to support.
+
+## Debugging
+
+If at any time you want to get more output from the script, set `DEBUG` to any value. 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+if [ "x${DEBUG}" != "x" ]; then
+  set -x
+fi
+
+REPO=${REPO:-"rancher"}
+PUSH=${PUSH:-""}
+
+build_image() {
+  pushd $1/$2
+
+  echo "building version: $1, arch: $2"
+
+  docker build -t $REPO/hyperkube:${1}-${2} .
+  
+  popd
+}
+
+push_manifest() {
+  VERSION=${1} && shift
+
+  cat > manifest.yml << EOM
+image: ${REPO}/hyperkube:${VERSION}
+manifests:
+EOM
+
+  for ARCH in "$@"; do
+    PLATFORM_ARCH=${ARCH}
+    if [ "${ARCH}" == "aarch64" ]; then
+      PLATFORM_ARCH=arm64
+    fi
+
+    cat >> manifest.yml <<EOM
+  - image: ${REPO}/hyperkube:${VERSION}-${ARCH}
+    platform:
+      architecture: ${PLATFORM_ARCH}
+      os: linux
+EOM
+  done
+
+  MANIFEST_OPTS=""
+  if [ "x${PRIVATE_REGISTRY}" != "x" ]; then
+    MANIFEST_OPTS = "--username ${REGISTRY_USERNAME} --password \"${REGISTRY_PASSWORD}\""
+  fi
+
+  manifest-tool $MANIFEST_OPTS push from-spec manifest.yml
+}
+
+for VERSION in $(ls -d v*); do
+  for ARCH in $(ls -d $VERSION/*); do
+    build_image $VERSION $(basename $ARCH)
+  done
+done
+
+if [ "x${PUSH}" != "x" ]; then
+  docker push $REPO/hyperkube
+
+  if [ "x`which manifest-tool`" == "x" ]; then
+    echo "Unable to push manifest, please install manifest-tool"
+    exit 1
+  fi
+
+  if [ "x${REPO}" != "rancher" ]; then
+    if [ "x${REGISTRY_USERNAME}" == "x" ]; then
+      echo "Unable to push manifest, expect REGISTRY_USERNAME to be set"
+      exit 1
+    fi
+  fi
+
+  for VERSION in $(ls -d v*); do
+    pushd $VERSION
+    push_manifest $VERSION `ls -d *`
+    rm -f manifest.yml
+    popd
+  done
+fi
+

--- a/v1.10/amd64/Dockerfile
+++ b/v1.10/amd64/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/google_containers/hyperkube:v1.10.5
+RUN clean-install apt-transport-https gnupg1 curl \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" > \
+    /etc/apt/sources.list.d/azure-cli.list \
+    && curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && apt-get purge gnupg \
+    && clean-install \
+    xfsprogs \
+    open-iscsi \
+    azure-cli \

--- a/v1.11/aarch64/Dockerfile
+++ b/v1.11/aarch64/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/google_containers/hyperkube:v1.11.3@sha256:2c8ed99c06ad96e5e747838833ec7bb538a8ee64bef94004bad1659401265311
+RUN clean-install apt-transport-https gnupg1 curl \
+    && echo "deb [arch=arm64] https://packages.microsoft.com/repos/azure-cli/ stretch main" > \
+    /etc/apt/sources.list.d/azure-cli.list \
+    && curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && apt-get purge gnupg \
+    && clean-install \
+    xfsprogs \
+    open-iscsi \
+    azure-cli \

--- a/v1.11/amd64/Dockerfile
+++ b/v1.11/amd64/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/google_containers/hyperkube:v1.11.3@sha256:f6ec5bb2e12ac585d58c14c6d7f08092244594fb4224551cabcffabdecf9d4ba
+RUN clean-install apt-transport-https gnupg1 curl \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" > \
+    /etc/apt/sources.list.d/azure-cli.list \
+    && curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && apt-get purge gnupg \
+    && clean-install \
+    xfsprogs \
+    open-iscsi \
+    azure-cli \

--- a/v1.12/aarch64/Dockerfile
+++ b/v1.12/aarch64/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/google_containers/hyperkube:v1.12.1@sha256:02c73330a4d5672ecf424221c3954c072c2190b7e89421ba994368e083181926
+RUN clean-install apt-transport-https gnupg1 curl \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" > \
+    /etc/apt/sources.list.d/azure-cli.list \
+    && curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && apt-get purge gnupg \
+    && clean-install \
+    xfsprogs \
+    open-iscsi \
+    azure-cli \

--- a/v1.12/amd64/Dockerfile
+++ b/v1.12/amd64/Dockerfile
@@ -1,0 +1,10 @@
+FROM gcr.io/google_containers/hyperkube:v1.12.1@sha256:7e76bcbe9e8bd16c748d84d9beb7e668b43de2c32790284d9544bd512c156469
+RUN clean-install apt-transport-https gnupg1 curl \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" > \
+    /etc/apt/sources.list.d/azure-cli.list \
+    && curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && apt-get purge gnupg \
+    && clean-install \
+    xfsprogs \
+    open-iscsi \
+    azure-cli \


### PR DESCRIPTION
## Not Included

* v1.8
* v1.9

## Included

* Adds support for building image for multiple architectures
  * Initial support for amd64 and aarch64 (see below for aarch64)
* Each architecture gets it's own ...
  * tag (format: tag-${ARCH})
  * Dockerfile (format: package/${ARCH}/Dockerfile)
* Manifest Creation and Publishing using [manifest-tool](https://github.com/estesp/manifest-tool)

## Known Issues

* Azure-CLI isn't going to work inside the AArch64 images. Microsoft doesn't maintain an aarch64/arm64 version of this in their deb repo.


## Why is it called AArch64?

It is arm64, but the more technically correct term. See https://static.docs.arm.com/100878/0100/fundamentals_of_armv8_a_100878_0100_en.pdf