### PR TITLE
Add v1.12 ARM64 image build support

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,6 @@
+FROM gcr.io/google_containers/hyperkube-arm64:v1.12.1
+RUN clean-install apt-transport-https gnupg1 curl \
+    && apt-get purge gnupg \
+    && clean-install \
+    xfsprogs \
+    open-iscsi


### PR DESCRIPTION
**Included**  
Add support for building Hyperkube v1.12.1 image for ARM64.
Since azure-cli does not support arm64, I removed the code installing azure-cli.

**Related issue**  
https://github.com/rancher/rancher/issues/16461

**Build Environment**  
The  ARM64 image needs to be built in an ARM64 environment.