### PR TITLE
Add arm64 docker file and drone multiarch CICD support for v1.12 k8s

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,10 +1,66 @@
----
-pipeline:
-  publish:
+kind: pipeline
+name: amd64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: publish-hyperkube-amd64
     image: plugins/docker
-    dockerfile: Dockerfile
-    repo: rancher/hyperkube
-    tag: ${DRONE_TAG}
-    secrets: [docker_username, docker_password]
+    settings:
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_password
+      dockerfile: Dockerfile
+      repo: rancher/hyperkube
+      tag: "${DRONE_TAG}-amd64"
     when:
-      event: tag
+      event:
+        - tag
+---
+kind: pipeline
+name: arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+  - name: publish-hyperkube-arm64
+    image: plugins/docker:linux-arm64
+    settings:
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_password
+      dockerfile: Dockerfile.arm64
+      repo: rancher/hyperkube
+      tag: "${DRONE_TAG}-arm64"
+    when:
+      event:
+        - tag
+---
+kind: pipeline
+name: manifest
+
+steps:
+  - name: push-manifest
+    image: plugins/manifest:1.0.2
+    settings:
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_password
+      target: "rancher/hyperkube:${DRONE_TAG}"
+      template: "rancher/hyperkube:${DRONE_TAG}-ARCH"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+    when:
+      event:
+        - tag
+depends_on:
+- amd64
+- arm64

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,6 @@
+FROM gcr.io/google_containers/hyperkube-arm64:v1.12.5
+RUN clean-install apt-transport-https gnupg1 curl \
+    && apt-get purge gnupg \
+    && clean-install \
+    xfsprogs \
+    open-iscsi


### PR DESCRIPTION
This PR includes the following changes.
- Added the arm64 dockerfile for build arm64 docker image.
- Added the drone1.0 config file for multiarch CICD.

The config file `.drone-multiarch.yml` and the rancher `dockerhub_username` and `dockerhub_password` need to be set to this repo in drone-1.0 server.

Issue
https://github.com/rancher/rancher/issues/16461
https://github.com/rancher/rancher/issues/16518