### PR TITLE
Add support for docker as required to kuryr-cni

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 FROM gcr.io/google_containers/hyperkube:v1.13.1
-RUN clean-install apt-transport-https gnupg1 curl \
+RUN clean-install apt-transport-https gnupg1 curl ca-certificates gnupg2 software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ stretch main" > \
     /etc/apt/sources.list.d/azure-cli.list \
     && curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && apt-get purge gnupg \
+    && apt-get purge gnupg -y \
     && clean-install \
     xfsprogs \
     open-iscsi \
     azure-cli \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io


### PR DESCRIPTION
I'm addking kuryr CNI to RKE. This step in needed to allow kubelet run kuryr-cni properly.

Kuryr is an openstack CNI to bring k8s to neutron. It allows to use all neutron features with k8s.