### PR TITLE
update k8s version for new hyperkube image (v1.15.11 -> v1.15.12)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/hyperkube:v1.15.11
+FROM gcr.io/google_containers/hyperkube:v1.15.12
 RUN sed -i -e 's!\bmain\b!main contrib!g' /etc/apt/sources.list && \
     apt-get update && apt-get upgrade -y && apt-get clean && \
     clean-install apt-transport-https gnupg1 curl zfsutils-linux \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/hyperkube-arm64:v1.15.11
+FROM gcr.io/google_containers/hyperkube-arm64:v1.15.12
 RUN sed -i -e 's!\bmain\b!main contrib!g' /etc/apt/sources.list && \
     apt-get update && apt-get upgrade -y && apt-get clean && \
     clean-install apt-transport-https gnupg1 curl zfsutils-linux \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -10,7 +10,7 @@ RUN if (-not (Get-Command Expand-7Zip -ErrorAction Ignore)) { \
             Exit 1; \
        } \
     }
-ENV K8S_VERSION v1.15.11
+ENV K8S_VERSION v1.15.12
 RUN $URL = ('https://dl.k8s.io/{0}/kubernetes-node-windows-amd64.tar.gz' -f $env:K8S_VERSION); \
     \
     function Expand-GZip ($inFile, $outFile) { \


### PR DESCRIPTION
Need a `rancher/hyperkube:v1.15.12` image for [this issue](https://github.com/rancher/rancher/issues/26958)