### PR TITLE
Update k8s version to v1.16.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,3 @@ RUN sed -i -e 's!\bmain\b!main contrib!g' /etc/apt/sources.list && \
     glusterfs-common \
     samba-common \
     arptables
-
-RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
-    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy && \
-    update-alternatives --set arptables /usr/sbin/arptables-legacy && \
-    update-alternatives --set ebtables /usr/sbin/ebtables-legacy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/hyperkube:v1.16.11
+FROM gcr.io/google_containers/hyperkube:v1.16.12
 RUN sed -i -e 's!\bmain\b!main contrib!g' /etc/apt/sources.list && \
     apt-get update && apt-get upgrade -y && apt-get clean && \
     clean-install apt-transport-https gnupg1 curl zfsutils-linux \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -17,8 +17,3 @@ RUN sed -i -e 's!\bmain\b!main contrib!g' /etc/apt/sources.list && \
     glusterfs-common \
     samba-common \
     arptables
-
-RUN update-alternatives --set iptables /usr/sbin/iptables-legacy && \
-    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy && \
-    update-alternatives --set arptables /usr/sbin/arptables-legacy && \
-    update-alternatives --set ebtables /usr/sbin/ebtables-legacy

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/hyperkube-arm64:v1.16.11
+FROM gcr.io/google_containers/hyperkube-arm64:v1.16.12
 RUN sed -i -e 's!\bmain\b!main contrib!g' /etc/apt/sources.list && \
     apt-get update && apt-get upgrade -y && apt-get clean && \
     clean-install apt-transport-https gnupg1 curl zfsutils-linux \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -10,7 +10,7 @@ RUN if (-not (Get-Command Expand-7Zip -ErrorAction Ignore)) { \
             Exit 1; \
        } \
     }
-ENV K8S_VERSION v1.16.11
+ENV K8S_VERSION v1.16.12
 RUN $URL = ('https://dl.k8s.io/{0}/kubernetes-node-windows-amd64.tar.gz' -f $env:K8S_VERSION); \
     \
     function Expand-GZip ($inFile, $outFile) { \


### PR DESCRIPTION
- Update k8s version to v1.16.12
- Remove `update-alternatives` since new base image includes [iptables-wrapper](https://github.com/kubernetes/kubernetes/blob/release-1.17/build/debian-iptables/Dockerfile)