### PR TITLE
Bump to v1.19.0 and use v0.0.1 of rancher/hyperkube-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM rancher/hyperkube-base:v0.0.1-rc3
+FROM rancher/hyperkube-base:v0.0.1
 
 COPY k8s-binaries/kube* /usr/local/bin/

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -10,7 +10,7 @@ RUN if (-not (Get-Command Expand-7Zip -ErrorAction Ignore)) { \
             Exit 1; \
        } \
     }
-ENV K8S_VERSION v1.19.0-rc.4
+ENV K8S_VERSION v1.19.0
 RUN $URL = ('https://dl.k8s.io/{0}/kubernetes-node-windows-amd64.tar.gz' -f $env:K8S_VERSION); \
     \
     function Expand-GZip ($inFile, $outFile) { \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-K8S_VERSION?=v1.19.0-rc.4
+K8S_VERSION?=v1.19.0
 
 ARCH?=amd64
 ALL_ARCH=amd64 arm64


### PR DESCRIPTION
Bump hyperkube to v1.19.0

https://github.com/rancher/rancher/issues/26717

Signed-off-by: Chris Kim <oats87g@gmail.com>