### PR TITLE
Update hyperkube to v1.18.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/hyperkube:v1.18.6
+FROM us.gcr.io/k8s-artifacts-prod/hyperkube:v1.18.8
 RUN sed -i -e 's!\bmain\b!main contrib!g' /etc/apt/sources.list && \
     apt-get update && apt-get upgrade -y && apt-get clean && \
     clean-install apt-transport-https gnupg1 curl zfsutils-linux \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM gcr.io/google_containers/hyperkube:v1.18.6
+FROM us.gcr.io/k8s-artifacts-prod/hyperkube:v1.18.8
 RUN sed -i -e 's!\bmain\b!main contrib!g' /etc/apt/sources.list && \
     apt-get update && apt-get upgrade -y && apt-get clean && \
     clean-install apt-transport-https gnupg1 curl zfsutils-linux \

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -10,7 +10,7 @@ RUN if (-not (Get-Command Expand-7Zip -ErrorAction Ignore)) { \
             Exit 1; \
        } \
     }
-ENV K8S_VERSION v1.18.6
+ENV K8S_VERSION v1.18.8
 RUN $URL = ('https://dl.k8s.io/{0}/kubernetes-node-windows-amd64.tar.gz' -f $env:K8S_VERSION); \
     \
     function Expand-GZip ($inFile, $outFile) { \


### PR DESCRIPTION
Repository has changed to be community owned under the domain `{asia,eu,us}.gcr.io/k8s-artifacts-prod`.
`gcr.io/google-containers`has also changed to `k8s.gcr.io`, but solely for backwards compatibility reasons and not for future use.