### PR TITLE
[v1.20] Update hyperkube-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM rancher/hyperkube-base:v0.0.7
+FROM rancher/hyperkube-base:v0.0.8
 
 COPY k8s-binaries/kube* /usr/local/bin/


### PR DESCRIPTION
Do not merge before https://github.com/rancher/hyperkube-base/pull/7
Related: https://github.com/rancher/rancher/issues/35709
Tag should be: `v1.20.14-rancher2`