### PR TITLE
[v1.21] Update hyperkube-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM rancher/hyperkube-base:v0.0.7
+FROM rancher/hyperkube-base:v0.0.8
 
 COPY k8s-binaries/kube* /usr/local/bin/


### PR DESCRIPTION
Do not merge before rancher/hyperkube-base#7
Related: rancher/rancher#35709
Tag should be: `v1.21.8-rancher2`