### PR TITLE
[v1.20] bump hyperkube base to v0.0.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM rancher/hyperkube-base:v0.0.10
+FROM rancher/hyperkube-base:v0.0.11
 
 COPY k8s-binaries/kube* /usr/local/bin/


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/36825

**Problem**
Build on tag failed because new vulnerabilities found in `hyperkube-base:v0.0.10`